### PR TITLE
feat: update user retrieval methods to use document number instead of…

### DIFF
--- a/domain/model/src/main/java/co/com/jcuadrado/model/user/gateways/UserRepository.java
+++ b/domain/model/src/main/java/co/com/jcuadrado/model/user/gateways/UserRepository.java
@@ -8,5 +8,5 @@ public interface UserRepository {
     Mono<User> saveUser(User user);
     Flux<User> getAllUsers();
     Mono<User> getUserByEmailOrDocumentNumber(String email, String documentNumber);
-    Mono<User> getUserByEmail(String email);
+    Mono<User> getUserByDocumentNumber(String documentNumber);
 }

--- a/domain/usecase/src/main/java/co/com/jcuadrado/usecase/user/UserUseCase.java
+++ b/domain/usecase/src/main/java/co/com/jcuadrado/usecase/user/UserUseCase.java
@@ -21,9 +21,9 @@ public record UserUseCase(
         .switchIfEmpty(userRepository.saveUser(validUser)));
     }
 
-    public Mono<User> getUserByEmail(String email) {
-        return this.userRepository.getUserByEmail(email)
-            .switchIfEmpty(Mono.error(new BusinessException(ErrorMessage.USER_NOT_FOUND, ErrorCode.NOT_FOUND)));
+    public Mono<User> getUserByDocumentNumber(String documentNumber) {
+        return this.userRepository.getUserByDocumentNumber(documentNumber)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorMessage.USER_NOT_FOUND, ErrorCode.NOT_FOUND)));
     }
 
     public Flux<User> getAllUsers() {

--- a/domain/usecase/src/test/java/co/com/jcuadrado/usecase/user/UserUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/jcuadrado/usecase/user/UserUseCaseTest.java
@@ -38,7 +38,8 @@ class UserUseCaseTest {
                 .email("juan.cuadrado@mail.com")
                 .baseSalary(BigDecimal.valueOf(10000000L))
                 .build();
-        when(repository.getUserByEmailOrDocumentNumber(user.getEmail(), user.getDocumentNumber())).thenReturn(Mono.empty());
+        when(repository.getUserByEmailOrDocumentNumber(user.getEmail(), user.getDocumentNumber()))
+                .thenReturn(Mono.empty());
         when(repository.saveUser(user)).thenReturn(Mono.just(user));
 
         Mono<User> result = useCase.saveUser(user);
@@ -173,7 +174,7 @@ class UserUseCaseTest {
     }
 
     @Test
-    void failedSaveUserBaseSalaryIsGreaterThanFifteenMillion(){
+    void failedSaveUserBaseSalaryIsGreaterThanFifteenMillion() {
         User user = User.builder()
                 .documentNumber("123456789")
                 .name("Juan")
@@ -202,7 +203,8 @@ class UserUseCaseTest {
                 .baseSalary(BigDecimal.valueOf(10000000.00))
                 .build();
 
-        when(repository.getUserByEmailOrDocumentNumber(user.getEmail(), user.getDocumentNumber())).thenReturn(Mono.just(user));
+        when(repository.getUserByEmailOrDocumentNumber(user.getEmail(), user.getDocumentNumber()))
+                .thenReturn(Mono.just(user));
         when(repository.saveUser(user)).thenReturn(Mono.just(user));
 
         Mono<User> result = useCase.saveUser(user);
@@ -220,8 +222,7 @@ class UserUseCaseTest {
     void successfulGetAllUsers() {
         Flux<User> users = Flux.just(
                 User.builder().email("test1@example.com").documentNumber("123456789").build(),
-                User.builder().email("test2@example.com").documentNumber("987654321").build()
-        );
+                User.builder().email("test2@example.com").documentNumber("987654321").build());
 
         when(repository.getAllUsers()).thenReturn(users);
 
@@ -246,52 +247,39 @@ class UserUseCaseTest {
     }
 
     @Test
-    void successGetUserByEmail() {
-        String email = "test@mail.com";
-        User user = User.builder().email(email).build();
+    void successfulGetUserByDocumentNumber() {
+        String documentNumber = "123456789";
+        User user = User.builder()
+                .documentNumber(documentNumber)
+                .name("Juan")
+                .lastName("Cuadrado")
+                .email("juan.cuadrado@mail.com")
+                .build();
 
-        when(repository.getUserByEmail(email)).thenReturn(Mono.just(user));
+        when(repository.getUserByDocumentNumber(documentNumber)).thenReturn(Mono.just(user));
 
-        Mono<User> result = useCase.getUserByEmail(email);
+        Mono<User> result = useCase.getUserByDocumentNumber(documentNumber);
 
         StepVerifier.create(result)
                 .expectNext(user)
                 .verifyComplete();
-
-        Mockito.verify(repository).getUserByEmail(email);
+        Mockito.verify(repository).getUserByDocumentNumber(documentNumber);
     }
 
     @Test
-    void  failedGetUserByEmailUserNotFound() {
-        String email = "test@mail.com";
-        when(repository.getUserByEmail(email)).thenReturn(Mono.empty());
-
-        Mono<User> result = useCase.getUserByEmail(email);
-
+    void failedGetUserByDocumentNumberNotFound() {
+        String documentNumber = "123456789";
+        when(repository.getUserByDocumentNumber(documentNumber)).thenReturn(Mono.empty());
+        Mono<User> result = useCase.getUserByDocumentNumber(documentNumber);
         StepVerifier.create(result)
                 .expectErrorSatisfies(error -> {
                     BusinessException ex = assertInstanceOf(BusinessException.class, error);
                     assertEquals(ErrorMessage.USER_NOT_FOUND, ex.getMessage());
+                    assertEquals(ErrorCode.NOT_FOUND, ex.getCode());
                 })
                 .verify();
-
-        Mockito.verify(repository).getUserByEmail(email);
-    }
-
-    @Test
-    void failedGetUserByEmail() {
-        String email = "test@mail.com";
-        when(repository.getUserByEmail(email)).thenReturn(Mono.error(new RuntimeException("Database error")));
-
-        Mono<User> result = useCase.getUserByEmail(email);
-
-        StepVerifier.create(result)
-                .expectErrorSatisfies(error -> {
-                    assertEquals("Database error", error.getMessage());
-                })
-                .verify();
-
-        Mockito.verify(repository).getUserByEmail(email);
+        Mockito.verify(repository).getUserByDocumentNumber(documentNumber);
+        Mockito.verifyNoMoreInteractions(repository);
     }
 
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/jcuadrado/r2dbc/repository/user/UserReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/jcuadrado/r2dbc/repository/user/UserReactiveRepository.java
@@ -9,5 +9,5 @@ import java.util.UUID;
 
 public interface UserReactiveRepository extends ReactiveCrudRepository<UserEntity, UUID>, ReactiveQueryByExampleExecutor<UserEntity> {
     Mono<UserEntity> findFirstByEmailOrDocumentNumber(String email, String documentNumber);
-    Mono<UserEntity> findByEmail(String email);
+    Mono<UserEntity> findByDocumentNumber(String documentNumber);
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/jcuadrado/r2dbc/repository/user/UserReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/jcuadrado/r2dbc/repository/user/UserReactiveRepositoryAdapter.java
@@ -49,7 +49,7 @@ public class UserReactiveRepositoryAdapter extends ReactiveAdapterOperations<
     }
 
     @Override
-    public Mono<User> getUserByEmail(String email) {
-        return super.repository.findByEmail(email).map(this::toEntity);
+    public Mono<User> getUserByDocumentNumber(String documentNumber) {
+        return super.repository.findByDocumentNumber(documentNumber).map(this::toEntity);
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/jcuadrado/api/UserHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/jcuadrado/api/UserHandler.java
@@ -27,26 +27,28 @@ public class UserHandler {
 
     public Mono<ServerResponse> listenSaveUser(ServerRequest serverRequest) {
         return serverRequest.bodyToMono(CreateUserDTO.class)
-            .flatMap(createUserDTO -> ValidationUtil.validateAndReturnError(validator, createUserDTO)
-                .switchIfEmpty(
-                    userUseCase.saveUser(userDTOMapper.toModel(createUserDTO))
-                        .transform(userDTOMapper::toDTOMono)
-                        .flatMap(userDTO -> ResponseUtil.buildSuccessResponse(userDTO, SuccessStatus.CREATED))
-                )
-            );
+                .flatMap(createUserDTO -> ValidationUtil.validateAndReturnError(validator, createUserDTO)
+                        .switchIfEmpty(
+                                userUseCase.saveUser(userDTOMapper.toModel(createUserDTO))
+                                        .transform(userDTOMapper::toDTOMono)
+                                        .flatMap(userDTO -> ResponseUtil.buildSuccessResponse(userDTO,
+                                                SuccessStatus.CREATED))));
     }
 
     /**
      * @param serverRequest This param is not used but is required by the framework.
      */
     public Mono<ServerResponse> listenGetAllUsers(ServerRequest serverRequest) {
-        return ServerResponse.ok().contentType(MediaType.APPLICATION_JSON).body(userDTOMapper.toDTOFlux(userUseCase.getAllUsers()), UserDTO.class);
+        return ServerResponse.ok().contentType(MediaType.APPLICATION_JSON)
+                .body(userDTOMapper.toDTOFlux(userUseCase.getAllUsers()), UserDTO.class);
     }
-
-    public Mono<ServerResponse> listenGetUserByEmail(ServerRequest serverRequest) {
+    
+    public Mono<ServerResponse> listenGetUserByDocumentNumber(ServerRequest serverRequest) {
         return ServerResponse.ok()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(userDTOMapper.toDTOMono(userUseCase
-                        .getUserByEmail(serverRequest.pathVariable(UserConstants.EMAIL_PATH_VARIABLE))), UserDTO.class);
+                        .getUserByDocumentNumber(
+                                serverRequest.pathVariable(UserConstants.DOCUMENT_NUMBER_PATH_VARIABLE))),
+                        UserDTO.class);
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/jcuadrado/api/UserRouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/jcuadrado/api/UserRouterRest.java
@@ -15,9 +15,9 @@ import static org.springframework.web.reactive.function.server.RequestPredicates
 public class UserRouterRest {
 
     @Bean
-    public RouterFunction<ServerResponse> userRouterFunction(UserHandler handler) {
+    RouterFunction<ServerResponse> userRouterFunction(UserHandler handler) {
         return RouterFunctions.route(POST(UserConstants.USERS_API_PATH), handler::listenSaveUser)
                 .andRoute(GET(UserConstants.USERS_API_PATH), handler::listenGetAllUsers)
-                .andRoute(GET(UserConstants.USERS_API_PATH + UserConstants.EMAIL_ENDPOINT), handler::listenGetUserByEmail);
+                .andRoute(GET(UserConstants.USERS_API_PATH + UserConstants.DOCUMENT_NUMBER_ENDPOINT), handler::listenGetUserByDocumentNumber);
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/jcuadrado/api/constant/UserConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/jcuadrado/api/constant/UserConstants.java
@@ -5,6 +5,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class UserConstants {
     public static final String USERS_API_PATH = "/api/users";
-    public static final String EMAIL_PATH_VARIABLE = "email";
-    public static final String EMAIL_ENDPOINT = "/{email}";
+    public static final String DOCUMENT_NUMBER_PATH_VARIABLE = "documentNumber";
+    public static final String DOCUMENT_NUMBER_ENDPOINT = "/{documentNumber}";
 }


### PR DESCRIPTION
This pull request refactors the user retrieval logic across the codebase to use `documentNumber` instead of `email` as the primary identifier for fetching individual users. This change affects the domain model, use case, repository interfaces, adapters, API handlers, routing, and constants, ensuring consistency and alignment with the new business requirement.

### Domain and Use Case Layer

* Updated the `UserRepository` interface and `UserUseCase` class to replace `getUserByEmail(String email)` with `getUserByDocumentNumber(String documentNumber)`, shifting the primary lookup from email to document number. [[1]](diffhunk://#diff-99df849a86b384d0e5f1d60e0416b7c701d51696665d14b5f4378ba05df70204L11-R11) [[2]](diffhunk://#diff-d14da078cb1c19d0b4bae8a79d610441fb694aef6a76e40ce87563cf9d37c084L24-R25)

### Infrastructure Layer

* Modified `UserReactiveRepository` and its adapter to use `findByDocumentNumber` instead of `findByEmail`, ensuring the persistence layer queries by document number. [[1]](diffhunk://#diff-f41c6b12a8d8be83693a76d8e4ac39ec2d21a4b42177c1f242342125fbfc3d45L12-R12) [[2]](diffhunk://#diff-a8d0938a25ea27f8c79a6abad45c2fdd3521105122861bac7226f4941a9ddc36L52-R53)

### API and Routing

* Refactored API handler methods and routing to support fetching users by document number instead of email, updating endpoint paths and parameter names accordingly. [[1]](diffhunk://#diff-bcf569af0dd79dac7d8362a03398ba7aac5e9b83d07a3378eb1fcf11b9c12b8dL34-R52) [[2]](diffhunk://#diff-89816b67264df99ee3e16255da398255285a8ddcfc1b8c5cea3ffbc1edd65540L18-R21) [[3]](diffhunk://#diff-82ad6746dac051a9d523ba9143db14dcca79053df4f3c0dd3dd3f4dc9df1b180L8-R9)

### Testing

* Updated and refactored unit tests to validate the new document number-based logic, including changing test method names, parameters, and verifications to reflect the new approach.

### Code Style

* Minor formatting improvements in test files for readability. [[1]](diffhunk://#diff-d8331e33d90c9e26030ee2590502cf594da965dee21c59010b9d6b86dea4f8f7L41-R42) [[2]](diffhunk://#diff-d8331e33d90c9e26030ee2590502cf594da965dee21c59010b9d6b86dea4f8f7L205-R207) [[3]](diffhunk://#diff-d8331e33d90c9e26030ee2590502cf594da965dee21c59010b9d6b86dea4f8f7L223-R225)… email, including API adjustments